### PR TITLE
swc-installation-test-2.py: Disable sympy, Cython, networkx, and mayavi.mlab

### DIFF
--- a/swc-installation-test-2.py
+++ b/swc-installation-test-2.py
@@ -115,10 +115,10 @@ CHECKS = [
     'scipy',
     'matplotlib',
     'pandas',
-    'sympy',
-    'Cython',
-    'networkx',
-    'mayavi.mlab',
+    #'sympy',
+    #'Cython',
+    #'networkx',
+    #'mayavi.mlab',
     ]
 
 CHECKER = {}


### PR DESCRIPTION
These are rarely used in SWC workshops, and many instructors are
pointing their students at these installation-test scripts without
customizing CHECKS first.  Until we get an easier way to configure the
checks, just make the default settings a bit more relaxed.

See #6 and #7.
