### PR TITLE
swc-installation-test-2.py: Add remote check configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@ For learners
 ============
 
 This directory contains scripts for testing your machine to make sure
-you have the software you'll need for your workshop installed.  See
-the comments at the head of each script for more details, but you'll
-basically want to see something like:
+you have the software you'll need for your workshop installed.  Your
+instructors should provide you with a URL listing the workshop's
+dependencies.  See the comments at the head of each script for more
+details, but you'll basically want to see something like:
 
     $ python swc-installation-test-1.py
     Passed
-    $ python swc-installation-test-2.py
+    $ python swc-installation-test-2.py --url https://swcarpentry.github.io/2015-11-09-abc/lessons.json
     check virtual-shell...  pass
     …
     Successes:
@@ -18,7 +19,7 @@ basically want to see something like:
 
 If you see something like:
 
-    $ python swc-installation-test-2.py
+    $ python swc-installation-test-2.py --url https://swcarpentry.github.io/2015-11-09-abc/lessons.json
     check virtual-shell...  fail
     …
     check for command line shell (virtual-shell) failed:
@@ -36,7 +37,7 @@ follow the suggestions to try and install any missing software.  For
 additional troubleshooting information, you can use the `--verbose`
 option:
 
-    $ python swc-installation-test-2.py --verbose
+    $ python swc-installation-test-2.py --url https://swcarpentry.github.io/2015-11-09-abc/lessons.json --verbose
     check virtual-shell...  fail
     …
     ==================
@@ -51,26 +52,81 @@ For instructors
 `swc-installation-test-1.py` is pretty simple, and just checks that
 the students have a recent enough version of Python installed that
 they'll be able to parse `swc-installation-test-2.py`.  The latter
-checks for a list of dependencies and prints error messages if a
+checks for your workshop's requirements and prints error messages if a
 package is not installed, or if the installed version is not current
-enough.  By default, the script checks for pretty much anything that
-has ever been used at a Software Carpentry workshop, which is probably
-not what you want for your particular workshop.
+enough.  When you setup your workshop, you should write a [JSON][]
+file listing the lessons you will cover.  For example:
 
-Before your workshop, you should go through
-`swc-installation-test-2.py` and comment any dependencies you don't
-need out of the `CHECKS` list.  You might also want to skim through
-the minimum version numbers listed where particular dependencies are
-defined (e.g. `('git', 'Git', (1, 7, 0), None)`).  For the most part,
-fairly conservative values have been selected, so students with modern
-machines should be fine.  If your workshop has stricter version
-requirements, feel free to bump them accordingly.
+```json
+{
+  "shell": {
+    "requirements": "https://raw.githubusercontent.com/swcarpentry/shell-novice/v5.4/requirements.json"
+  },
+  "git": {
+    "requirements": "https://raw.githubusercontent.com/swcarpentry/git-novice/v5.3/requirements.json"
+  },
+  "python": {
+    "requirements": "https://raw.githubusercontent.com/swcarpentry/python-novice-inflammation/v5.4/requirements.json"
+  },
+  "sql": {
+    "requirements": "https://raw.githubusercontent.com/swcarpentry/sql-novice-survey/v5.7/requirements.json"
+  }
+}
+```
 
-Similarly, the virtual dependencies can be satisfied by any of several
-packages.  If you don't want to support a particular package (e.g. if
-you have no Emacs experience and don't want to be responsible for
-students who show up with Emacs as their only editor), you can comment
-out that particular `or_dependency`.
+The lesson names (“shell”, “git”, …) are only used for logging, and
+you may add other attributes or entries that don't define
+`requirements` if you wish.  `swc-installation-test-2.py` will collect
+requirements from the lesson requirement files and then check to make
+sure they are all satisfied.  If you want to use a lesson that does
+not provide a `requirements.json`, you can write your own requirement
+file for that lesson and use your URL in your workshop's JSON:
 
-Finally, don't forget to post your modified scripts somewhere where
-your students can download them!
+```json
+{
+  "shell": {
+    "requirements": "https://swcarpentry.github.io/2015-11-09-abc/shell-requirements.json"
+  }
+}
+```
+
+For lesson maintainers
+======================
+
+By providing a `requirements.json` file, you make it easy for others
+to discover its requirements.  For example, [instructors can write
+workshop requirements](#for-instructors) referencing your listing.
+The [JSON][] file should be an object whose keys are check names and
+whose values are objects that may contain a `minimum-version` key.  If
+`minimum-version` is set, it must be an array specifying the minimum
+version of the checked software compatible with your lesson.  For
+example:
+
+```json
+{
+  "git": {
+    "minimum-version": [1, 7, 0]
+  },
+  "virtual-editor": {},
+  "virtual-browser": {},
+  "virtual-shell": {}
+}
+```
+
+You may add other attributes to the per-check objects if you wish.
+
+Virtual dependencies can be satisfied by any of several packages.  If
+you don't want to support a particular package (e.g. if you have no
+Emacs experience and don't want to be responsible for students who
+show up with Emacs as their only editor), you can blacklist the
+package:
+
+```json
+{
+  "virtual-editor": {
+    "blacklist": ["emacs"]
+  }
+}
+```
+
+[JSON]: http://json.org/

--- a/README.md
+++ b/README.md
@@ -59,17 +59,20 @@ file listing the lessons you will cover.  For example:
 
 ```json
 {
-  "shell": {
-    "requirements": "https://raw.githubusercontent.com/swcarpentry/shell-novice/v5.4/requirements.json"
-  },
-  "git": {
-    "requirements": "https://raw.githubusercontent.com/swcarpentry/git-novice/v5.3/requirements.json"
-  },
-  "python": {
-    "requirements": "https://raw.githubusercontent.com/swcarpentry/python-novice-inflammation/v5.4/requirements.json"
-  },
-  "sql": {
-    "requirements": "https://raw.githubusercontent.com/swcarpentry/sql-novice-survey/v5.7/requirements.json"
+  "instructions": "https://swcarpentry.github.io/2015-11-09-abc/#setup",
+  "lessons": {
+    "shell": {
+      "requirements": "https://raw.githubusercontent.com/swcarpentry/shell-novice/v5.4/requirements.json"
+    },
+    "git": {
+      "requirements": "https://raw.githubusercontent.com/swcarpentry/git-novice/v5.3/requirements.json"
+    },
+    "python": {
+      "requirements": "https://raw.githubusercontent.com/swcarpentry/python-novice-inflammation/v5.4/requirements.json"
+    },
+    "sql": {
+      "requirements": "https://raw.githubusercontent.com/swcarpentry/sql-novice-survey/v5.7/requirements.json"
+    }
   }
 }
 ```

--- a/swc-installation-test-2.py
+++ b/swc-installation-test-2.py
@@ -11,9 +11,14 @@ Run the script and follow the instructions it prints at the end.
 This script requires at least Python 2.6.  You can check the version
 of Python that you have installed with 'swc-installation-test-1.py'.
 
-By default, this script will test for all the dependencies your
-instructor thinks you need.  If you want to test for a different set
-of packages, you can list them on the command line.  For example:
+To test for a particular event's requirements, point the script at a
+lesson listing:
+
+  python swc-installation-test-2.py --url https://swcarpentry.github.io/2015-11-09-abc/lessons.json
+
+replacing the URL with your event's lesson listing.  If you want to
+test for a different set of packages, you can list them on the command
+line.  For example:
 
   python swc-installation-test-2.py git virtual-editor
 
@@ -28,9 +33,7 @@ dependency.
 # Dependency class. You can refer to the code to see which package
 # comes under which type of dependency.
 
-# The CHECKER dictionary stores information about all the dependencies
-# and CHECKS stores list of the dependencies which are to be checked in
-# the current workshop.
+# The CHECKER dictionary stores information about all the dependencies.
 
 # In the "__name__ == '__main__'" block, we launch all the checks with
 # check() function, which prints information about the tests as they run
@@ -58,6 +61,7 @@ except ImportError:  # Python 2.6 and earlier
                 module = getattr(module, n)
             return module
     _importlib = _Importlib()
+import json as _json
 import logging as _logging
 import os as _os
 import platform as _platform
@@ -65,6 +69,10 @@ import re as _re
 import shlex as _shlex
 import subprocess as _subprocess
 import sys as _sys
+try:  # Python 3.x
+    import urllib.request as _urllib_request
+except ImportError:  # Python 2.x
+    import urllib2 as _urllib_request  # for urlopen()
 import xml.etree.ElementTree as _element_tree
 
 
@@ -75,47 +83,6 @@ if not hasattr(_shlex, 'quote'):  # Python versions older than 3.3
 
 
 __version__ = '0.1'
-
-# Comment out any entries you don't need
-CHECKS = [
-# Shell
-    'virtual-shell',
-# Editors
-    'virtual-editor',
-# Browsers
-    'virtual-browser',
-# Version control
-    'git',
-    'hg',              # Command line tool
-    #'mercurial',       # Python package
-    'EasyMercurial',
-# Build tools and packaging
-    'make',
-    'virtual-pypi-installer',
-    'setuptools',
-    #'xcode',
-# Testing
-    'nosetests',       # Command line tool
-    'nose',            # Python package
-    'py.test',         # Command line tool
-    'pytest',          # Python package
-# SQL
-    'sqlite3',         # Command line tool
-    'sqlite3-python',  # Python package
-# Python
-    'python',
-    'ipython',         # Command line tool
-    'IPython',         # Python package
-    'argparse',        # Useful for utility scripts
-    'numpy',
-    'scipy',
-    'matplotlib',
-    'pandas',
-    #'sympy',
-    #'Cython',
-    #'networkx',
-    #'mayavi.mlab',
-    ]
 
 CHECKER = {}
 
@@ -246,11 +213,9 @@ class DependencyError (Exception):
         return '\n'.join(lines)
 
 
-def check(checks=None):
+def check(checks):
     successes = []
     failures = []
-    if not checks:
-        checks = CHECKS
     for check in checks:
         try:
             checker = CHECKER[check]
@@ -876,7 +841,7 @@ CHECKER['other-editor'] = EditorTaskDependency(
 
 
 for name,long_name,dependencies in [
-        ('virtual-shell', 'command line shell', (
+        ('virtual-shell', 'command line shell', [
             'bash',
             'dash',
             'ash',
@@ -885,8 +850,8 @@ for name,long_name,dependencies in [
             'csh',
             'tcsh',
             'sh',
-            )),
-        ('virtual-editor', 'text/code editor', (
+            ]),
+        ('virtual-editor', 'text/code editor', [
             'emacs',
             'xemacs',
             'vim',
@@ -899,21 +864,89 @@ for name,long_name,dependencies in [
             'textmate',
             'textwrangler',
             'other-editor',  # last because it requires user interaction
-            )),
-        ('virtual-browser', 'web browser', (
+            ]),
+        ('virtual-browser', 'web browser', [
             'firefox',
             'google-chrome',
             'chromium',
             'safari',
-            )),
-        ('virtual-pypi-installer', 'PyPI installer', (
+            ]),
+        ('virtual-pypi-installer', 'PyPI installer', [
             'pip',
             'easy_install',
-            )),
+            ]),
         ]:
     CHECKER[name] = VirtualDependency(
         name=name, long_name=long_name, or_dependencies=dependencies)
 del name, long_name, dependencies  # cleanup namespace
+
+
+def _get_json(url):
+    response = _urllib_request.urlopen(url)  # not context manager in Python 2
+    info = response.info()
+    response_bytes = response.read()
+    if hasattr(info, 'get_content_charset'):
+        # Python 3, info is email.message.Message
+        charset = info.get_content_charset('UTF-8')
+    else:  # Python 2, info is mimetools.Message
+        charset = info.getparam('charset') or 'UTF-8'
+    response.close()
+    json = response_bytes.decode(charset)
+    return _json.loads(json)
+
+
+def _update_checker(url, checker, config):
+    if 'minimum-version' in config:
+        version = config['minimum-version']
+        if (not checker.minimum_version or
+            version > checker.minimum_version):
+            _LOG.debug('set minimum version for {} to {}'.format(
+                checker.name, version))
+            checker.minimum_version = tuple(version)
+    if 'blacklist' in config:
+        _LOG.debug('blacklist or-dependencies for {}: {}'.format(
+            checker.name, config['blacklist']))
+        for check in config['blacklist']:
+            try:
+                checker.or_dependencies.remove(check)
+            except ValueError:
+                try:
+                    c = CHECKER[check]
+                except KeyError as e:
+                    _LOG.warning(
+                        '{} blacklists an unrecognized check: {}'.format(
+                            url, requirement))
+                    raise InvalidCheck(check)# from e
+                try:
+                    checker.or_dependencies.remove(c)
+                except ValueError:
+                    _LOG.debug(
+                        'not blacklisting missing or-dependency for {}: {}'
+                        .format(checker.name, check))
+                    pass  # maybe someone else already removed it
+
+
+def get_checks(url):
+    checks = set()
+    _LOG.debug('get lessons from {}'.format(url))
+    lessons = _get_json(url=url)
+    for lesson, lesson_config in lessons.items():
+        requirements_url = lesson_config.get('requirements')
+        if requirements_url:
+            _LOG.debug('get requirements for {} from {}'.format(
+                lesson, requirements_url))
+            requirements = _get_json(url=requirements_url)
+            for check, config in requirements.items():
+                checks.add(check)
+                try:
+                    checker = CHECKER[check]
+                except KeyError as e:
+                    _LOG.warning(
+                        '{} requires an unrecognized check: {}'.format(
+                            requirements_url, check))
+                    raise InvalidCheck(check)# from e
+                _update_checker(url=requirements_url, checker=checker, config=config)
+    return sorted(checks)
 
 
 def _print_info(key, value, indent=19):
@@ -977,6 +1010,9 @@ if __name__ == '__main__':
         '-v', '--verbose', action='store_true',
         help=('print additional information to help troubleshoot '
               'installation issues'))
+    parser.add_option(
+        '-u', '--url', metavar='URL',
+        help='URL for the workshop repository or GitHub pages website')
     options,args = parser.parse_args()
 
     if options.verbose:
@@ -989,6 +1025,13 @@ if __name__ == '__main__':
             print(key)
         _sys.exit(0)
 
+    if options.url:
+        if args:
+            print(
+                'you should set either --url or explicit checks, not both',
+                file=_sys.stderr)
+            _sys.exit(1)
+        args = get_checks(url=options.url)
     try:
         passed = check(args)
     except InvalidCheck as e:

--- a/swc-installation-test-2.py
+++ b/swc-installation-test-2.py
@@ -1014,10 +1014,19 @@ if __name__ == '__main__':
     epilog = __doc__
     parser.format_epilog = lambda formatter: '\n' + epilog
     parser.add_option(
+        '-l', '--list', action='store_true',
+        help='list available checks and exit')
+    parser.add_option(
         '-v', '--verbose', action='store_true',
         help=('print additional information to help troubleshoot '
               'installation issues'))
     options,args = parser.parse_args()
+
+    if options.list:
+        for key in sorted(CHECKER.keys()):
+            print(key)
+        _sys.exit(0)
+
     try:
         passed = check(args)
     except InvalidCheck as e:

--- a/swc-installation-test-2.py
+++ b/swc-installation-test-2.py
@@ -124,6 +124,9 @@ if _platform.system() == 'win32':
     _ROOT_PATH = 'c:\\'
 
 
+_LOG = _logging.getLogger(__name__)
+
+
 class InvalidCheck (KeyError):
     def __init__(self, check):
         super(InvalidCheck, self).__init__(check)
@@ -962,6 +965,8 @@ def print_suggestions(instructor_fallback=True):
 if __name__ == '__main__':
     import optparse as _optparse
 
+    _LOG.addHandler(_logging.StreamHandler())
+
     parser = _optparse.OptionParser(usage='%prog [options] [check...]')
     epilog = __doc__
     parser.format_epilog = lambda formatter: '\n' + epilog
@@ -973,6 +978,11 @@ if __name__ == '__main__':
         help=('print additional information to help troubleshoot '
               'installation issues'))
     options,args = parser.parse_args()
+
+    if options.verbose:
+        _LOG.setLevel(_logging.DEBUG)
+    else:
+        _LOG.setLevel(_logging.WARNING)
 
     if options.list:
         for key in sorted(CHECKER.keys()):

--- a/swc-installation-test-2.py
+++ b/swc-installation-test-2.py
@@ -657,11 +657,9 @@ class EasyInstallDependency (CommandDependency):
 
 
 class PythonDependency (Dependency):
-    def __init__(self, name='python', long_name='Python version',
-                 minimum_version=(2, 6), **kwargs):
+    def __init__(self, name='python', long_name='Python version', **kwargs):
         super(PythonDependency, self).__init__(
-            name=name, long_name=long_name, minimum_version=minimum_version,
-            **kwargs)
+            name=name, long_name=long_name, **kwargs)
 
     def _get_version(self):
         return _sys.version
@@ -744,57 +742,54 @@ def _program_files_paths(*args):
 CHECKER['python'] = PythonDependency()
 
 
-for command,long_name,minimum_version,paths in [
-        ('sh', 'Bourne Shell', None, None),
-        ('ash', 'Almquist Shell', None, None),
-        ('bash', 'Bourne Again Shell', None, None),
-        ('csh', 'C Shell', None, None),
-        ('ksh', 'KornShell', None, None),
-        ('dash', 'Debian Almquist Shell', None, None),
-        ('tcsh', 'TENEX C Shell', None, None),
-        ('zsh', 'Z Shell', None, None),
-        ('git', 'Git', (1, 7, 0), None),
-        ('hg', 'Mercurial', (2, 0, 0), None),
-        ('EasyMercurial', None, (1, 3), None),
-        ('pip', None, None, None),
-        ('sqlite3', 'SQLite 3', None, None),
-        ('nosetests', 'Nose', (1, 0, 0), None),
-        ('ipython', 'IPython script', (1, 0), None),
-        ('emacs', 'Emacs', None, None),
-        ('xemacs', 'XEmacs', None, None),
-        ('vim', 'Vim', None, None),
-        ('vi', None, None, None),
-        ('nano', 'Nano', None, None),
-        ('gedit', None, None, None),
-        ('kate', 'Kate', None, None),
-        ('notepad++', 'Notepad++', None,
+for command,long_name,paths in [
+        ('sh', 'Bourne Shell', None),
+        ('ash', 'Almquist Shell', None),
+        ('bash', 'Bourne Again Shell', None),
+        ('csh', 'C Shell', None),
+        ('ksh', 'KornShell', None),
+        ('dash', 'Debian Almquist Shell', None),
+        ('tcsh', 'TENEX C Shell', None),
+        ('zsh', 'Z Shell', None),
+        ('git', 'Git', None),
+        ('hg', 'Mercurial', None),
+        ('EasyMercurial', None, None),
+        ('pip', None, None),
+        ('sqlite3', 'SQLite 3', None),
+        ('nosetests', 'Nose', None),
+        ('ipython', 'IPython script', None),
+        ('emacs', 'Emacs', None),
+        ('xemacs', 'XEmacs', None),
+        ('vim', 'Vim', None),
+        ('vi', None, None),
+        ('nano', 'Nano', None),
+        ('gedit', None, None),
+        ('kate', 'Kate', None),
+        ('notepad++', 'Notepad++',
          _program_files_paths('Notepad++', 'notepad++.exe')),
-        ('firefox', 'Firefox', None,
+        ('firefox', 'Firefox',
          _program_files_paths('Mozilla Firefox', 'firefox.exe')),
-        ('google-chrome', 'Google Chrome', None,
+        ('google-chrome', 'Google Chrome',
          _program_files_paths('Google', 'Chrome', 'Application', 'chrome.exe')
          ),
-        ('chromium', 'Chromium', None, None),
+        ('chromium', 'Chromium', None),
         ]:
     if not long_name:
         long_name = command
     CHECKER[command] = CommandDependency(
-        command=command, paths=paths, long_name=long_name,
-        minimum_version=minimum_version)
-del command, long_name, minimum_version, paths  # cleanup namespace
+        command=command, paths=paths, long_name=long_name)
+del command, long_name, paths  # cleanup namespace
 
 
-CHECKER['make'] = MakeDependency(command='make', minimum_version=None)
+CHECKER['make'] = MakeDependency(command='make')
 
 
 CHECKER['easy_install'] = EasyInstallDependency(
-    command='easy_install', long_name='Setuptools easy_install',
-    minimum_version=None)
+    command='easy_install', long_name='Setuptools easy_install')
 
 
 CHECKER['py.test'] = CommandDependency(
-    command='py.test', version_stream='stderr',
-    minimum_version=None)
+    command='py.test', version_stream='stderr')
 
 
 for paths,name,long_name in [
@@ -824,67 +819,27 @@ for paths,name,long_name in [
 del paths, name, long_name  # cleanup namespace
 
 
-for package,name,long_name,minimum_version,and_dependencies in [
-        ('nose', None, 'Nose Python package',
-         CHECKER['nosetests'].minimum_version, None),
-        ('pytest', None, 'pytest Python package',
-         CHECKER['py.test'].minimum_version, None),
-        ('jinja2', 'jinja', 'Jinja', (2, 6), None),
-        ('zmq', 'pyzmq', 'PyZMQ', (2, 1, 4), None),
-        ('IPython', None, 'IPython Python package',
-         CHECKER['ipython'].minimum_version, [
+for package,name,long_name,and_dependencies in [
+        ('nose', None, 'Nose Python package', None),
+        ('pytest', None, 'pytest Python package', None),
+        ('jinja2', 'jinja', 'Jinja', None),
+        ('zmq', 'pyzmq', 'PyZMQ', None),
+        ('IPython', None, 'IPython Python package', [
              'jinja',
              'tornado',
              'pyzmq',
-             VirtualDependency(
-                 name='virtual-browser-ipython',
-                 long_name='IPython-compatible web browser',
-                 or_dependencies=[
-                     CommandDependency(
-                         command=CHECKER['firefox'].command,
-                         paths=CHECKER['firefox'].paths,
-                         name='{0}-for-ipython'.format(
-                             CHECKER['firefox'].name),
-                         long_name='{0} for IPython'.format(
-                             CHECKER['firefox'].long_name),
-                         minimum_version=(6, 0)),
-                     CommandDependency(
-                         command=CHECKER['google-chrome'].command,
-                         paths=CHECKER['google-chrome'].paths,
-                         name='{0}-for-ipython'.format(
-                             CHECKER['google-chrome'].name),
-                         long_name='{0} for IPython'.format(
-                             CHECKER['google-chrome'].long_name),
-                         minimum_version=(13, 0)),
-                     CommandDependency(
-                         command=CHECKER['chromium'].command,
-                         paths=CHECKER['chromium'].paths,
-                         name='{0}-for-ipython'.format(
-                             CHECKER['chromium'].name),
-                         long_name='{0} for IPython'.format(
-                             CHECKER['chromium'].long_name),
-                         minimum_version=(13, 0)),
-                     VersionPlistCommandDependency(
-                         command=CHECKER['safari'].command,
-                         paths=CHECKER['safari'].paths,
-                         key=CHECKER['safari'].key,
-                         name='{0}-for-ipython'.format(
-                             CHECKER['safari'].name),
-                         long_name='{0} for IPython'.format(
-                             CHECKER['safari'].long_name),
-                         minimum_version=(5, 0)),
-                 ]),
+             'virtual-browser',
          ]),
-        ('argparse', None, 'Argparse', None, None),
-        ('numpy', None, 'NumPy', None, None),
-        ('scipy', None, 'SciPy', None, None),
-        ('matplotlib', None, 'Matplotlib', None, None),
-        ('pandas', None, 'Pandas', (0, 8), None),
-        ('sympy', None, 'SymPy', None, None),
-        ('Cython', None, None, None, None),
-        ('networkx', None, 'NetworkX', None, None),
-        ('mayavi.mlab', None, 'MayaVi', None, None),
-        ('setuptools', None, 'Setuptools', None, None),
+        ('argparse', None, 'Argparse', None),
+        ('numpy', None, 'NumPy', None),
+        ('scipy', None, 'SciPy', None),
+        ('matplotlib', None, 'Matplotlib', None),
+        ('pandas', None, 'Pandas', None),
+        ('sympy', None, 'SymPy', None),
+        ('Cython', None, None, None),
+        ('networkx', None, 'NetworkX', None),
+        ('mayavi.mlab', None, 'MayaVi', None),
+        ('setuptools', None, 'Setuptools', None),
         ]:
     if not name:
         name = package
@@ -894,26 +849,23 @@ for package,name,long_name,minimum_version,and_dependencies in [
     if and_dependencies:
         kwargs['and_dependencies'] = and_dependencies
     CHECKER[name] = PythonPackageDependency(
-        package=package, name=name, long_name=long_name,
-        minimum_version=minimum_version, **kwargs)
+        package=package, name=name, long_name=long_name, **kwargs)
 # cleanup namespace
-del package, name, long_name, minimum_version, and_dependencies, kwargs
+del package, name, long_name, and_dependencies, kwargs
 
 
 CHECKER['mercurial'] = MercurialPythonPackage(
     package='mercurial.util', name='mercurial',
-    long_name='Mercurial Python package',
-    minimum_version=CHECKER['hg'].minimum_version)
+    long_name='Mercurial Python package')
 
 
 CHECKER['tornado'] = TornadoPythonPackage(
-    package='tornado', name='tornado', long_name='Tornado', minimum_version=(2, 0))
+    package='tornado', name='tornado', long_name='Tornado')
 
 
 CHECKER['sqlite3-python'] = SQLitePythonPackage(
     package='sqlite3', name='sqlite3-python',
-    long_name='SQLite Python package',
-    minimum_version=CHECKER['sqlite3'].minimum_version)
+    long_name='SQLite Python package')
 
 
 CHECKER['other-editor'] = EditorTaskDependency(

--- a/swc-installation-test-2.py
+++ b/swc-installation-test-2.py
@@ -65,10 +65,6 @@ import re as _re
 import shlex as _shlex
 import subprocess as _subprocess
 import sys as _sys
-try:  # Python 3.x
-    import urllib.parse as _urllib_parse
-except ImportError:  # Python 2.x
-    import urllib as _urllib_parse  # for quote()
 import xml.etree.ElementTree as _element_tree
 
 

--- a/swc-installation-test-2.py
+++ b/swc-installation-test-2.py
@@ -104,7 +104,7 @@ class InvalidCheck (KeyError):
 
 
 class DependencyError (Exception):
-    _default_url = 'http://software-carpentry.org/setup/'
+    default_url = 'https://swcarpentry.github.io/workshop-template/#setup'
     _setup_urls = {  # (system, version, package) glob pairs
         ('*', '*', 'Cython'): 'http://docs.cython.org/src/quickstart/install.html',
         ('Linux', '*', 'EasyMercurial'): 'http://easyhg.org/download.html#download-linux',
@@ -196,7 +196,7 @@ class DependencyError (Exception):
                     _fnmatch.fnmatch(version, v) and
                     _fnmatch.fnmatch(package, p)):
                 return url
-        return self._default_url
+        return self.default_url
 
     def __str__(self):
         url = self.get_url()
@@ -929,8 +929,11 @@ def _update_checker(url, checker, config):
 def get_checks(url):
     checks = set()
     _LOG.debug('get lessons from {}'.format(url))
-    lessons = _get_json(url=url)
-    for lesson, lesson_config in lessons.items():
+    setup = _get_json(url=url)
+    instructions = setup.get('instructions')
+    if instructions:
+        DependencyError.default_url = instructions
+    for lesson, lesson_config in setup.get('lessons', {}).items():
         requirements_url = lesson_config.get('requirements')
         if requirements_url:
             _LOG.debug('get requirements for {} from {}'.format(


### PR DESCRIPTION
Fixes #2.

The old `CHECKS` approach didn't work very well, because many
instructors would forget to edit `CHECKS` and learners would be
confused when they failed checks for packages that they didn't
actually need (but which were still listed in `CHECKS`) (see [a](https://github.com/swcarpentry/workshop-template/issues/136),
[b](https://github.com/swcarpentry/workshop-template/issues/180), [c](https://github.com/swcarpentry/workshop-template/issues/181), [d](https://github.com/swcarpentry/workshop-template/issues/258), …).  This commit makes:

```
$ ./swc-installation-test-2.py
```

a no-op.  Users will either have to explicitly specify checks on the
command line:

```
$ ./swc-installation-test-2.py virtual-editor
```

or point the tester at an instructor-provided config:

```
$ ./swc-installation-test-2.py --url https://swcarpentry.github.io/2015-11-09-abc/lessons.json
```

Because dependencies for a given lesson can be tricky and are shared
by all lesson consumers, it offloads the bulk of the
requirement-listing to lesson maintainers.  Once that work is done,
instructors can just list out the lessons they're covering (which is
also useful for tools like [AMY](https://github.com/swcarpentry/amy) who would like an automatic way to
determine what is being taught).

SWC generally prefers YAML to JSON, but I've gone with JSON here to stick
with stock Python 2.6+ support.  I've also changed some `or_dependency`
definitions from tuples to lists so I can mutate them with `.remove()`.

Docs on the new workflows and the JSON files are in [the](https://github.com/wking/swc-setup-installation-test/tree/lesson-dependencies#for-instructors) [README](https://github.com/wking/swc-setup-installation-test/tree/lesson-dependencies#for-lesson-maintainers).
